### PR TITLE
Add option to turn off instruction message

### DIFF
--- a/lua/jj-diffconflicts/init.lua
+++ b/lua/jj-diffconflicts/init.lua
@@ -289,11 +289,13 @@ h.setup_ui = function(conflicts, show_history)
   h.setup_diff_splits(conflicts)
 
   -- Display usage message
-  vim.cmd.redraw()
-  vim.notify(
-    "Resolve conflicts leftward then save. Use :cq to abort.",
-    vim.log.levels.WARN
-  )
+  if not vim.g.jj_diffconflicts_turn_off_instructions then
+    vim.cmd.redraw()
+    vim.notify(
+      "Resolve conflicts leftward then save. Use :cq to abort.",
+      vim.log.levels.WARN
+    )
+  end
 end
 
 -- Set up a two-way diff for conflict resolution.


### PR DESCRIPTION
By setting `g:jj_diffconflicts_turn_off_instructions=1` (or other values which parse to truthy in lua) we turn off the initial 'warning' message of how to use and exit the difftool.

Fixes #4.

This is the simplest change I could do to allow disabling the notify function and I currently enable it in my jj config just like the `marker_length` option: 

```toml
merge-args = [
    "-c", "let g:jj_diffconflicts_marker_length=$marker_length",
    "-c", "let g:jj_diffconflicts_turn_off_instructions=1",
    "-c", "JJDiffConflicts!", "$output", "$base", "$left", "$right"
]
```

I would be happy to add it to the docs as well if you think this would be useful to implement as it is currently.

Otherwise it may be useful to switch to a `require('jj-diffconflicts').setup()` function to implement options like this as well.