### PR TITLE
Emit `JJDiffConflictsReady` event when conflict resolution UI is loaded

### DIFF
--- a/doc/jj-diffconflicts.txt
+++ b/doc/jj-diffconflicts.txt
@@ -41,6 +41,8 @@ Command ~
     invoking it through `jj resolve`. If no [count] is given, then the merge
     tool will use the default length of 7 to parse conflict markers.
 
+    When the UI is ready, the |JJDiffConflictsReady| event is dispatched.
+
     See also: |g:jj_diffconflicts_no_command|
 
 
@@ -73,6 +75,29 @@ g:jj_diffconflicts_show_usage_message    *g:jj_diffconflicts_show_usage_message*
     Example:
         `vim.g.jj_diffconflicts_show_usage_message=false`
 
+
+Autocommand ~
+
+JJDiffConflictsReady                                      *JJDiffConflictsReady*
+
+   This |User| event is dispatched when the conflict resolution UI is loaded.
+   This can be used to run custom code.
+
+   For example, to set a keymap that only does something in the
+   conflict-resolution buffer:
+>
+      vim.api.nvim_create_autocmd("User", {
+        pattern = "JJDiffConflictsReady",
+        desc = "..."
+        callback = function()
+          vim.keymap.set("n", "<leader>x", function()
+            if vim.b.jj_diffconflicts_buftype == "conflicts" then
+              ...
+            end
+          end)
+        end,
+      })
+<
 
 Health check ~
 

--- a/lua/jj-diffconflicts/init.lua
+++ b/lua/jj-diffconflicts/init.lua
@@ -293,6 +293,9 @@ h.setup_ui = function(conflicts, show_history, show_usage_message)
   h.setup_diff_splits(conflicts)
   vim.cmd.redraw()
 
+  -- Dispatch `JJDiffConflictsReady` event
+  vim.cmd.doautocmd({ "User", "JJDiffConflictsReady" })
+
   -- Display usage message
   if show_usage_message then
     vim.notify(
@@ -317,6 +320,7 @@ h.setup_diff_splits = function(conflicts)
   local right_side = h.get_content_for_side("right_side", conflicts, conflicted_content)
   vim.api.nvim_buf_set_lines(0, 0, -1, false, right_side)
   vim.cmd.file("snapshot")
+  vim.api.nvim_buf_set_var(0, "jj_diffconflicts_buftype", "snapshot")
   vim.cmd([[setlocal nomodifiable readonly buftype=nofile bufhidden=delete nobuflisted]])
   vim.cmd.diffthis()
 
@@ -324,6 +328,7 @@ h.setup_diff_splits = function(conflicts)
   vim.cmd.wincmd("p")
   local left_side = h.get_content_for_side("left_side", conflicts, conflicted_content)
   vim.api.nvim_buf_set_lines(0, 0, -1, false, left_side)
+  vim.api.nvim_buf_set_var(0, "jj_diffconflicts_buftype", "conflicts")
   vim.cmd.diffthis()
 
   -- Ensure diff highlighting is up to date
@@ -365,6 +370,7 @@ h.setup_history_view = function()
   local load_history_split = function(name)
     vim.cmd.buffer(name) -- open buffer whose name matches the given `name`
     vim.cmd.file(name) -- set the file name
+    vim.api.nvim_buf_set_var(0, "jj_diffconflicts_buftype", "history_" .. name)
     vim.cmd([[setlocal statusline=%t]]) -- only display the file name in status line
     vim.cmd([[setlocal nomodifiable readonly]])
     vim.cmd.diffthis()

--- a/tests/test_jj_diffconflicts.lua
+++ b/tests/test_jj_diffconflicts.lua
@@ -6,6 +6,13 @@ local child = MiniTest.new_child_neovim()
 local setup_child = function()
   child.lua([[vim.opt.runtimepath:append(vim.fn.getcwd())]])
   child.lua([[jj = require("jj-diffconflicts")]])
+
+  -- Track how many times JJDiffConflictsReady User event is triggered
+  child.lua([[
+    _G.event_count = 0
+    local callback = function() _G.event_count = _G.event_count + 1 end
+    vim.api.nvim_create_autocmd('User', { pattern = 'JJDiffConflictsReady', callback = callback})
+  ]])
 end
 local set_lines = function(lines) child.api.nvim_buf_set_lines(0, 0, -1, true, lines) end
 local read_file = function(filename) return vim.iter(io.lines(filename)):totable() end
@@ -35,34 +42,46 @@ T["run"] = MiniTest.new_set({
 T["run"]["displays UI"] = function()
   set_lines(read_file("tests/data/fruits.txt"))
   child.lua("jj.run(false, 7)")
+
   expect.reference_screenshot(child.get_screenshot(), SCREENSHOT.fruits)
+
+  -- Check that the JJDiffConflictsReady event was triggered once
+  eq(child.lua_get("_G.event_count"), 1)
+
+  -- Check that the current buffer is the "conflicts" buffer
+  eq(child.lua_get("vim.b.jj_diffconflicts_buftype"), "conflicts")
 end
 T["run"]["displays an error when no valid conflict"] = function()
   set_lines({ "hello world" })
   child.lua("jj.run(false, 7)")
   expect.reference_screenshot(child.get_screenshot())
+  eq(child.lua_get("_G.event_count"), 0)
 end
 T["run"]["handles conflicts with different marker length"] = function()
   set_lines(read_file("tests/data/long_markers.txt"))
   child.lua("jj.run(false, 15)")
   expect.reference_screenshot(child.get_screenshot(), SCREENSHOT.long_markers)
+  eq(child.lua_get("_G.event_count"), 1)
 end
 T["run"]["does not work with wrong marker length"] = function()
   set_lines(read_file("tests/data/long_markers.txt"))
   child.lua("jj.run(false, 7)")
   expect.reference_screenshot(child.get_screenshot())
+  eq(child.lua_get("_G.event_count"), 0)
 end
 T["run"]["uses g:jj_diffconflicts_marker_length"] = function()
   set_lines(read_file("tests/data/long_markers.txt"))
   child.g.jj_diffconflicts_marker_length = 15
   child.lua("jj.run(false, nil)")
   expect.reference_screenshot(child.get_screenshot(), SCREENSHOT.long_markers)
+  eq(child.lua_get("_G.event_count"), 1)
 end
 T["run"]["defaults to marker length of 7"] = function()
   set_lines(read_file("tests/data/fruits.txt"))
   eq(child.lua_get("vim.g.jj_diffconflicts_marker_length"), vim.NIL)
   child.lua("jj.run(false, nil)")
   expect.reference_screenshot(child.get_screenshot(), SCREENSHOT.fruits)
+  eq(child.lua_get("_G.event_count"), 1)
 end
 T["run"]["raises error for invalid marker length"] = function()
   set_lines(read_file("tests/data/fruits.txt"))
@@ -70,23 +89,27 @@ T["run"]["raises error for invalid marker length"] = function()
     function() child.lua("jj.run(false, 'hello')") end,
     "marker_length: expected positive number"
   )
+  eq(child.lua_get("_G.event_count"), 0)
 end
 T["run"]["handles multiple conflicts"] = function()
   set_lines(read_file("tests/data/multiple_conflicts.txt"))
   child.o.lines = 36
   child.lua("jj.run(false, 7)")
   expect.reference_screenshot(child.get_screenshot(), SCREENSHOT.multiple_conflicts)
+  eq(child.lua_get("_G.event_count"), 1)
 end
 T["run"]["handles missing newlines conflicts"] = function()
   set_lines(read_file("tests/data/missing_newline_markers.txt"))
   child.lua("jj.run(false, 7)")
   expect.reference_screenshot(child.get_screenshot(), SCREENSHOT.missing_newline)
+  eq(child.lua_get("_G.event_count"), 1)
 end
 T["run"]["hides usage message when g:jj_diffconflicts_show_usage_message is false"] = function()
   set_lines(read_file("tests/data/fruits.txt"))
   child.g.jj_diffconflicts_show_usage_message = false
   child.lua("jj.run(false, 7)")
   expect.reference_screenshot(child.get_screenshot(), SCREENSHOT.no_usage_message)
+  eq(child.lua_get("_G.event_count"), 1)
 end
 
 T["history view"] = MiniTest.new_set()
@@ -100,8 +123,12 @@ T["history view"]["displays UI"] = function()
   setup_child()
 
   child.lua("jj.run(true, 7)")
+  eq(child.lua_get("_G.event_count"), 1)
+  eq(child.lua_get("vim.b.jj_diffconflicts_buftype"), "conflicts")
+
   child.cmd("tabnext")
   expect.reference_screenshot(child.get_screenshot())
+  eq(child.lua_get("vim.b.jj_diffconflicts_buftype"), "history_base")
 end
 
 return T


### PR DESCRIPTION
This can be used to run custom code, like defining keymaps that are only active for the jj-diffconflicts plugin.

In addition, the `vim.b.jj_diffconflicts_buftype` buffer-scoped variable is set on each of the buffers created by the plugin. The possible values are:

- "conflicts": The 'left-side' that contains the conflicts to edit
- "snapshot": The read-only 'right-side'
- "history_base": The middle pane of the history view that contains the merge base.
- "history_left": The leftmost pane of the history view that contains the "left" side of the conflict.
- "history_right": The rightmost pane of the history view that contains the "right" side of the conflict.