### PR TITLE
Drop support for Jujutsu v0.17.1 and below

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ But perhaps the best way is to [try it yourself](#test-repository).
 
 ## Installation
 
-`jj-diffconflicts` requires Neovim v0.10.0 or above.
+`jj-diffconflicts` requires Neovim v0.10.0 or above and Jujutsu v0.18.0 or above.
 It can be installed like any other Neovim plugin.
 
 It only supports conflicts that use the (default) "diff" conflict marker style (c.f. `ui.conflict-marker-style` configuration value).

--- a/doc/jj-diffconflicts.txt
+++ b/doc/jj-diffconflicts.txt
@@ -48,18 +48,6 @@ Command ~
 
 Options ~
 
-g:jj_diffconflicts_jujutsu_version          *g:jj_diffconflicts_jujutsu_version*
-
-    Specify the version of Jujutsu that is in use. This can matter because
-    different versions differ in how they generate conflict markers.
-
-    If unset (the default), `jj-diffconflicts` will detect the version by
-    executing `jj --version`. You can set this variable if running the `jj`
-    binary is not desirable.
-
-    Example:
-        `vim.g.jj_diffconflicts_jujutsu_version="0.17.1"`
-
 g:jj_diffconflicts_no_command                    *g:jj_diffconflicts_no_command*
 
     Set this variable if you don't want the |:JJDiffConflicts| command to be

--- a/lua/jj-diffconflicts/health.lua
+++ b/lua/jj-diffconflicts/health.lua
@@ -1,4 +1,5 @@
 local M = {}
+local h = {}
 
 -- Health check for detecting potential issues with running the plugin.
 -- See `:help health-dev`.
@@ -26,25 +27,35 @@ M.check = function()
     end
   end
 
-  local ok, version = pcall(require("jj-diffconflicts").get_jj_version)
+  local ok, version = pcall(h.get_jj_version)
   if not ok then
     vim.health.error("Could not get Jujutsu version: " .. version)
   else
-    vim.health.info(string.format("Detected Jujutsu version: %s", version))
-  end
-
-  local version_override = vim.g.jj_diffconflicts_jujutsu_version
-  if version_override == nil then
-    vim.health.info("g:jj_diffconflicts_jujutsu_version is unset")
-  else
-    local msg = string.format("g:jj_diffconflicts_jujutsu_version = %q", version_override)
-    local ok = pcall(vim.version.parse, version_override)
-    if ok then
-      vim.health.info(msg)
+    local min_version = vim.version.parse("0.18.0")
+    if vim.version.ge(version, min_version) then
+      vim.health.ok(string.format("Jujutsu version: %s", version))
     else
-      vim.health.error(msg)
+      vim.health.error(
+        string.format(
+          "Jujutsu version: %s (%s or above is required)",
+          version,
+          min_version
+        )
+      )
     end
   end
+end
+
+-- Return a table representing a software version that can be used as an
+-- argument to `vim.version.cmp`.
+h.get_jj_version = function()
+  local version_cmd = vim.system({ "jj", "--version" }):wait()
+  if version_cmd.code ~= 0 then
+    -- Only keep first line of error message
+    error(vim.split(version_cmd.stderr, "\n")[1])
+  end
+
+  return vim.version.parse(version_cmd.stdout)
 end
 
 return M

--- a/lua/jj-diffconflicts/init.lua
+++ b/lua/jj-diffconflicts/init.lua
@@ -14,22 +14,13 @@ local h = {}
 -- includes a history view that displays the two sides of the conflict and
 -- their ancestor.
 M.run = function(show_history, marker_length)
-  local ok, jj_version = pcall(M.get_jj_version)
-  if not ok then
-    vim.notify(
-      "jj-diffconflicts: could not get jujutsu version, assuming latest version",
-      vim.log.levels.ERROR
-    )
-    jj_version = { math.huge, math.huge, math.huge }
-  end
-
   if marker_length == 0 or marker_length == nil then
     marker_length = vim.g.jj_diffconflicts_marker_length
     if marker_length == "" or marker_length == nil then
       marker_length = 7
     end
   end
-  local patterns = h.get_patterns(jj_version, marker_length)
+  local patterns = h.get_patterns(marker_length)
 
   local lines = vim.api.nvim_buf_get_lines(0, 0, -1, true)
   local ok, raw_conflicts = pcall(h.extract_conflicts, patterns, lines)
@@ -85,7 +76,7 @@ end
 -- Define regular expression patterns to be used to detect conflict markers. We
 -- cannot just define them as constants, since they can vary based on Jujutsu's
 -- version or provided marker length.
-h.get_patterns = function(jj_version, marker_length)
+h.get_patterns = function(marker_length)
   vim.validate({
     marker_length = {
       marker_length,
@@ -102,26 +93,14 @@ h.get_patterns = function(jj_version, marker_length)
     snapshot = string.rep("+", marker_length),
   }
 
-  if vim.version.lt(jj_version, { 0, 18, 0 }) then
-    -- Versions prior to v0.18.0 don't include trailing explanations
-    return {
-      top = "^" .. marker.top .. "$",
-      bottom = "^" .. marker.bottom .. "$",
-      -- We need to double `marker.diff` to escape the `%` symbols
-      diff = "^" .. marker.diff .. marker.diff .. "$",
-      diff_cont = "^" .. marker.diff_cont .. "$",
-      snapshot = "^" .. marker.snapshot .. "$",
-    }
-  else
-    return {
-      top = "^" .. marker.top .. " .+$",
-      bottom = "^" .. marker.bottom .. " .+$",
-      -- We need to double `marker.diff` to escape the `%` symbols
-      diff = "^" .. marker.diff .. marker.diff .. " .+$",
-      diff_cont = "^" .. marker.diff_cont .. " .+$",
-      snapshot = "^" .. marker.snapshot .. " .+$",
-    }
-  end
+  return {
+    top = "^" .. marker.top .. " .+$",
+    bottom = "^" .. marker.bottom .. " .+$",
+    -- We need to double `marker.diff` to escape the `%` symbols
+    diff = "^" .. marker.diff .. marker.diff .. " .+$",
+    diff_cont = "^" .. marker.diff_cont .. " .+$",
+    snapshot = "^" .. marker.snapshot .. " .+$",
+  }
 end
 
 -- Extract conflict sections from the buffer.

--- a/lua/jj-diffconflicts/init.lua
+++ b/lua/jj-diffconflicts/init.lua
@@ -49,28 +49,6 @@ M.run = function(show_history, marker_length)
   h.setup_ui(conflicts, show_history)
 end
 
--- Return a table representing a software version that can be used as an
--- argument to `vim.version.cmp`.
---
--- If the `g:jj_diffconflicts_jujutsu_version` variable is set, then it will be
--- used as the version. Otherwise we run the `jj` binary to find its version.
---
--- The function is exported because it is used by the plugin health check.
-M.get_jj_version = function()
-  if vim.g.jj_diffconflicts_jujutsu_version ~= nil then
-    -- Escape hatch if running `jj` binary is not desirable
-    return vim.version.parse(vim.g.jj_diffconflicts_jujutsu_version)
-  end
-
-  local version_cmd = vim.system({ "jj", "--version" }):wait()
-  if version_cmd.code ~= 0 then
-    -- Only keep first line of error message
-    h.err(vim.split(version_cmd.stderr, "\n")[1])
-  end
-
-  return vim.version.parse(version_cmd.stdout)
-end
-
 -- Helpers --------------------------------------------------------------------
 
 -- Define regular expression patterns to be used to detect conflict markers. We

--- a/tests/test_internal.lua
+++ b/tests/test_internal.lua
@@ -8,7 +8,7 @@ local jj = require("jj-diffconflicts")
 
 local read_file = function(filename) return vim.iter(io.lines(filename)):totable() end
 
-local default_patterns = jj.get_patterns(jj.get_jj_version(), 7)
+local default_patterns = jj.get_patterns(7)
 
 local T = MiniTest.new_set()
 


### PR DESCRIPTION
This allows us to simplify how we define conflict markers patterns. In addition, the `get_version` function was moved to the health check module (since this is now its only user), and the  `g:jj_diffconflicts_jujutsu_version` option was removed (since it's not useful anymore).

Jujutsu v0.18.0 was released nearly two years ago. Given that back then Jujutsu was still an experimental system with frequent changes used by early adopters, it's likely that no one is still using an older version. And even if somehow one of those early adopters still needed support for older versions, they would likely be the type of person who could figure out how to make it work for them.